### PR TITLE
テスト実行時にのみ実行ディレクトを変更できるようにする

### DIFF
--- a/lib/pbmenv.rb
+++ b/lib/pbmenv.rb
@@ -16,7 +16,23 @@ require_relative "pbmenv/services/use_version_service"
 require_relative "pbmenv/services/download_src_service"
 
 module Pbmenv
-  PBM_DIR = "/usr/share/pbm"
+  PBM_DIR = "/usr/share/pbm" # NOTE: pbmから参照している
+  DEFAULT_PBM_DIR = PBM_DIR
+
+  @current_pbm_dir = DEFAULT_PBM_DIR
+
+  # @param [String] to_dir
+  # @return [void]
+  # NOTE: テスト用
+  def self.chdir(to_dir)
+    raise(ArgumentError, 'テスト以外では実行できません') unless defined?(RSpec)
+    @current_pbm_dir = to_dir
+  end
+
+  # @return [String]
+  def self.pbm_dir
+    @current_pbm_dir
+  end
 
   # @return [Pbmenv::DirectoryObject]
   def self.current_directory
@@ -29,7 +45,7 @@ module Pbmenv
 
   # @return [Array<Pbmenv::VersionObject>]
   def self.installed_versions
-    unsorted_dirs = Dir.glob("#{Pbmenv::PBM_DIR}/v*")
+    unsorted_dirs = Dir.glob("#{Pbmenv.pbm_dir}/v*")
     sorted_version_names = unsorted_dirs.map { |name| Pathname.new(name).basename.to_s =~ /^v([\d.]+)/ && $1 }.compact.sort_by {|x| Gem::Version.new(x) }
     sorted_version_names.map do |version_name|
       VersionObject.new(
@@ -42,7 +58,7 @@ module Pbmenv
 
   # @deprecated
   def self.versions
-    unsorted_dirs = Dir.glob("#{Pbmenv::PBM_DIR}/v*")
+    unsorted_dirs = Dir.glob("#{Pbmenv.pbm_dir}/v*")
     unsorted_dirs.map { |name| Pathname.new(name).basename.to_s =~ /^v([\d.]+)/ && $1 }.compact.sort_by {|x| Gem::Version.new(x) }.compact
   end
 

--- a/lib/pbmenv/version_pathname.rb
+++ b/lib/pbmenv/version_pathname.rb
@@ -7,11 +7,11 @@ module Pbmenv
     end
 
     def version_path
-      File.join(PBM_DIR, "v#{version}")
+      File.join(Pbmenv.pbm_dir, "v#{version}")
     end
 
     def version_path_without_v
-      File.join(PBM_DIR, "#{version}")
+      File.join(Pbmenv.pbm_dir, "#{version}")
     end
 
     def app_rb_path
@@ -65,11 +65,11 @@ module Pbmenv
     end
 
     def self.current
-      File.join(PBM_DIR, "current")
+      File.join(Pbmenv.pbm_dir, "current")
     end
 
     def self.shared
-      File.join(PBM_DIR, "shared")
+      File.join(Pbmenv.pbm_dir, "shared")
     end
   end
 end

--- a/spec/pbmenv_spec.rb
+++ b/spec/pbmenv_spec.rb
@@ -2,11 +2,7 @@ require "spec_helper"
 
 describe Pbmenv do
   def purge_pbm_dir
-    `rm -rf /usr/share/pbm`
-  end
-
-  before do
-    raise("ファイルを読み書きするのでmacではやらない方がいいです") unless ENV["CI"]
+    `rm -rf #{Pbmenv.pbm_dir}`
   end
 
   before(:each) do
@@ -97,14 +93,14 @@ describe Pbmenv do
       it 'currentにシムリンクが貼っている' do
         expect(subject).to eq(true)
         latest_version = Pbmenv.available_versions.detect { |x| x == target_version }
-        version_path = "/usr/share/pbm/v#{latest_version}"
-        expect(Pbmenv.current_directory.readlink).to eq("/usr/share/pbm/v#{target_version}")
+        version_path = "#{Pbmenv.pbm_dir}/v#{latest_version}"
+        expect(Pbmenv.current_directory.readlink).to eq("#{Pbmenv.pbm_dir}/v#{target_version}")
         expect(Dir.exist?(version_path)).to eq(true)
         expect(File.exist?("#{version_path}/app.rb")).to eq(true)
         expect(File.exist?("#{version_path}/README.md")).to eq(true)
         expect(File.exist?("#{version_path}/setting.yml")).to eq(true)
-        expect(Dir.exist?("/usr/share/pbm/shared")).to eq(true)
-        expect(File.read("/usr/share/pbm/shared/device_id")).to be_a(String)
+        expect(Dir.exist?("#{Pbmenv.pbm_dir}/shared")).to eq(true)
+        expect(File.read("#{Pbmenv.pbm_dir}/shared/device_id")).to be_a(String)
       end
     end
 
@@ -122,14 +118,14 @@ describe Pbmenv do
       it 'currentにシムリンクが貼っている' do
         subject
         latest_version = Pbmenv.available_versions.first
-        version_path = "/usr/share/pbm/v#{latest_version}"
-        expect(Pbmenv.current_directory.readlink).to match(%r!/usr/share/pbm/v[\d.]+!)
+        version_path = "#{Pbmenv.pbm_dir}/v#{latest_version}"
+        expect(Pbmenv.current_directory.readlink).to match(%r!#{Pbmenv.pbm_dir}/v[\d.]+!)
         expect(Dir.exist?(version_path)).to eq(true)
         expect(File.exist?("#{version_path}/app.rb")).to eq(true)
         expect(File.exist?("#{version_path}/README.md")).to eq(true)
         expect(File.exist?("#{version_path}/setting.yml")).to eq(true)
-        expect(Dir.exist?("/usr/share/pbm/shared")).to eq(true)
-        expect(File.read("/usr/share/pbm/shared/device_id")).to be_a(String)
+        expect(Dir.exist?("#{Pbmenv.pbm_dir}/shared")).to eq(true)
+        expect(File.read("#{Pbmenv.pbm_dir}/shared/device_id")).to be_a(String)
       end
     end
   end
@@ -148,14 +144,14 @@ describe Pbmenv do
 
         it 'currentにシムリンクが貼っている' do
           subject
-          expect(Pbmenv.current_directory.readlink).to eq("/usr/share/pbm/v0.1.6")
+          expect(Pbmenv.current_directory.readlink).to eq("#{Pbmenv.pbm_dir}/v0.1.6")
         end
 
         context 'インストールしていないバージョンをuseするとき' do
           it 'currentのシムリンクを更新しない' do
             subject
             Pbmenv.use("0.1.7")
-            expect(Pbmenv.current_directory.readlink).to eq("/usr/share/pbm/v0.1.6")
+            expect(Pbmenv.current_directory.readlink).to eq("#{Pbmenv.pbm_dir}/v0.1.6")
           end
         end
 
@@ -163,7 +159,7 @@ describe Pbmenv do
           it 'currentにシムリンクを貼る' do
             subject
             Pbmenv.use("v0.1.6")
-            expect(Pbmenv.current_directory.readlink).to eq("/usr/share/pbm/v0.1.6")
+            expect(Pbmenv.current_directory.readlink).to eq("#{Pbmenv.pbm_dir}/v0.1.6")
           end
         end
       end
@@ -177,7 +173,7 @@ describe Pbmenv do
 
         it '最後のバージョンでcurrentにシムリンクが貼っている' do
           subject
-          expect(Pbmenv.current_directory.readlink).to eq("/usr/share/pbm/v0.1.6")
+          expect(Pbmenv.current_directory.readlink).to eq("#{Pbmenv.pbm_dir}/v0.1.6")
         end
       end
     end
@@ -204,7 +200,7 @@ describe Pbmenv do
 
       it 'currentに0.1.6のシムリンクは貼らない' do
         subject
-        expect(Pbmenv.current_directory.readlink).to eq("/usr/share/pbm/v0.1.6")
+        expect(Pbmenv.current_directory.readlink).to eq("#{Pbmenv.pbm_dir}/v0.1.6")
       end
 
       # すでに別のバージョンが入っていないとuseが実行されるので、別のバージョンが入っている必要がある
@@ -213,7 +209,7 @@ describe Pbmenv do
 
         it 'currentに0.1.20.1のシムリンクは貼る' do
           subject
-          expect(Pbmenv.current_directory.readlink).to eq("/usr/share/pbm/v0.1.20.1")
+          expect(Pbmenv.current_directory.readlink).to eq("#{Pbmenv.pbm_dir}/v0.1.20.1")
         end
       end
     end
@@ -238,7 +234,7 @@ describe Pbmenv do
       it "URLの行がアンコメントアウトされていること" do
         subject
         target_version = decompress_procon_pbm_man_versions.first
-        a_pbm_path = "/usr/share/pbm/v#{target_version}"
+        a_pbm_path = "#{Pbmenv.pbm_dir}/v#{target_version}"
         expect(File.read("#{a_pbm_path}/app.rb")).to match(%r!^  config.api_servers = 'https://pbm-cloud.herokuapp.com'$!)
       end
     end
@@ -254,7 +250,7 @@ describe Pbmenv do
 
         it "URLの行がアンコメントアウトされていること" do
           subject
-          a_pbm_path = "/usr/share/pbm/v#{target_version}"
+          a_pbm_path = "#{Pbmenv.pbm_dir}/v#{target_version}"
           expect(File.exist?("#{a_pbm_path}/app.rb.erb")).to eq(false)
           # 特定行をアンコメントしていること
           expect(File.read("#{a_pbm_path}/app.rb")).to match(%r!^  config.api_servers = \['https://pbm-cloud.herokuapp.com'\]$!)
@@ -268,7 +264,7 @@ describe Pbmenv do
 
         it "URLの行がコメントアウトされていること" do
           subject
-          a_pbm_path = "/usr/share/pbm/v#{target_version}"
+          a_pbm_path = "#{Pbmenv.pbm_dir}/v#{target_version}"
           expect(File.exist?("#{a_pbm_path}/app.rb.erb")).to eq(false)
           # 特定行をコメントアウトしていること
           expect(File.read("#{a_pbm_path}/app.rb")).to match(%r!^  # config.api_servers = \['https://pbm-cloud.herokuapp.com'\]$!)
@@ -332,6 +328,16 @@ describe Pbmenv do
         expect(actual.map(&:name)).to eq(
           ["0.0.1", "0.2.2", "0.2.3", "0.2.4", "0.2.5", "0.2.6", "0.10.1"]
         )
+      end
+    end
+
+    describe '.chdir' do
+      subject { Pbmenv.chdir('/dist_path') }
+
+      it do
+        expect(Pbmenv.pbm_dir).to eq('/tmp/pbm')
+        subject
+        expect(Pbmenv.pbm_dir).to eq('/dist_path')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,11 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before do
+    system('mkdir -p /tmp/pbm')
+    Pbmenv.chdir('/tmp/pbm')
+  end
+
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
   # compatibility in RSpec 3). It causes shared context metadata to be

--- a/spec/support/correct_pbm_dir_examples.rb
+++ b/spec/support/correct_pbm_dir_examples.rb
@@ -1,22 +1,22 @@
 RSpec.shared_examples 'correct_pbm_dir_spec' do
-  it '/usr/share/pbm/v#{target_version}/ にファイルを作成すること' do
+  it '#{Pbmenv.pbm_dir}/v#{target_version}/ にファイルを作成すること' do
     subject
-    a_pbm_path = "/usr/share/pbm/v#{target_version}"
-    expect(Dir.exist?("/usr/share/pbm/v#{target_version}")).to eq(true)
-    expect(File.exist?("/usr/share/pbm/v#{target_version}/app.rb")).to eq(true)
+    a_pbm_path = "#{Pbmenv.pbm_dir}/v#{target_version}"
+    expect(Dir.exist?("#{Pbmenv.pbm_dir}/v#{target_version}")).to eq(true)
+    expect(File.exist?("#{Pbmenv.pbm_dir}/v#{target_version}/app.rb")).to eq(true)
     expect(File.exist?("#{a_pbm_path}/README.md")).to eq(true)
     expect(File.exist?("#{a_pbm_path}/setting.yml")).to eq(true)
     expect(File.exist?("#{a_pbm_path}/systemd_units/pbm.service")).to eq(true)
   end
 
-  it '/usr/share/pbm/v#{target_version}/device_idを作成すること' do
+  it '#{Pbmenv.pbm_dir}/v#{target_version}/device_idを作成すること' do
     subject
-    expect(File.readlink("/usr/share/pbm/v#{target_version}/device_id")).to eq("/usr/share/pbm/shared/device_id")
+    expect(File.readlink("#{Pbmenv.pbm_dir}/v#{target_version}/device_id")).to eq("#{Pbmenv.pbm_dir}/shared/device_id")
   end
 
-  it '/usr/share/pbm/shared/device_idを作成すること' do
+  it '#{Pbmenv.pbm_dir}/shared/device_idを作成すること' do
     subject
-    expect(File.read("/usr/share/pbm/shared/device_id")).to be_a(String)
+    expect(File.read("#{Pbmenv.pbm_dir}/shared/device_id")).to be_a(String)
   end
 
   it '解凍したファイルを削除していること' do

--- a/spec/support/fake_version_dir_factory.rb
+++ b/spec/support/fake_version_dir_factory.rb
@@ -1,10 +1,10 @@
 module FakeVersionDirFactory
   # @param [String]
   def self.create(version_name, symlink_to_current: false)
-    `mkdir -p /usr/share/pbm/v#{version_name}`
+    `mkdir -p #{Pbmenv.pbm_dir}/v#{version_name}`
 
     if symlink_to_current
-      `ln -s /usr/share/pbm/v#{version_name} #{Pbmenv.current_directory.path}`
+      `ln -s #{Pbmenv.pbm_dir}/v#{version_name} #{Pbmenv.current_directory.path}`
     end
   end
 end


### PR DESCRIPTION
今までだと /tmp へ書き込みをするので、ホスト側でテストを実行するとpermission errorが起きていた。
この修正で書き込み先を変更できるようになるのでホストでテストが実行できるようになる。